### PR TITLE
Custom serialization again, replacing default for now, 

### DIFF
--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -74,8 +74,16 @@ end
 
 class CustomThing < ActiveRecord::Base
   belongs_to :post
-
-  serialize :value
+  class ArrayPack
+    def self.load(str)
+      str.split(',').collect(&:to_i)
+    end
+    def self.dump(int_array)
+      int_array.join(',')
+    end
+  end
+  
+  serialize :value, ArrayPack
 end
 
 class Account < ActiveRecord::Base


### PR DESCRIPTION
Replacing default for now, later can add another field.  One with default, one with custom.

This custom serialization works if the object is dup'ed, but when the object is part of a relation it throws an exception.
