### PR TITLE
Cannot currently set the value of an object to false or nil. I can under...

### DIFF
--- a/lib/amoeba.rb
+++ b/lib/amoeba.rb
@@ -195,12 +195,12 @@ module Amoeba
 
           defs.each do |d|
             d.each do |k,v|
-              @coercions[k] = v if v
+              @coercions[k] = v
             end
           end
         else
           defs.each do |k,v|
-            @coercions[k] = v if v
+            @coercions[k] = v
           end
         end
         @coercions


### PR DESCRIPTION
...stand (somewhat) not wanting to enable users to set values to nil since it duplicates the functionality of #nullify, but users should be able to set value to false.  Personally, I don't see the harm in allowing users to update a value to nil and left off the condition 'unless v.nil?' from each of those lines.
