### PR TITLE
#47 only freeze hash and array values

### DIFF
--- a/lib/amoeba/config.rb
+++ b/lib/amoeba/config.rb
@@ -40,7 +40,7 @@ module Amoeba
     DEFAULTS.freeze
 
     DEFAULTS.each do |key, value|
-      value.freeze
+      value.freeze if value.is_a?(Array) || value.is_a?(Hash)
       class_eval <<-EOS, __FILE__, __LINE__ + 1
         def #{key}          # def enabled
           @config[:#{key}]  #   @config[:enabled]


### PR DESCRIPTION
Fixes #47. There is no need to freeze the false, nil and :dup values. The array and hash values should be frozen.