### PR TITLE
Add #include_associations and #exclude_associations

### DIFF
--- a/lib/amoeba/config.rb
+++ b/lib/amoeba/config.rb
@@ -113,6 +113,10 @@ module Amoeba
       push_value_to_hash({ value => options }, :includes)
     end
 
+    def include_associations(*values)
+      values.flatten.each { |v| include_association(v) }
+    end
+
     # TODO: remove this method in v3.0.0
     def include_field(value = nil)
       warn 'include_field is deprecated and will be removed in version 3.0.0; please use include_association instead'
@@ -123,6 +127,10 @@ module Amoeba
       enable
       @config[:includes] = {}
       push_value_to_hash({ value => options }, :excludes)
+    end
+
+    def exclude_associations(*values)
+      values.flatten.each { |v| exclude_association(v) }
     end
 
     # TODO: remove this method in v3.0.0

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -272,8 +272,8 @@ class Company < ActiveRecord::Base
   has_many :customers
 
   amoeba do
-    include_association :employees
-    include_association :customers
+    include_associations :employees,
+                        :customers
   end
 end
 
@@ -283,8 +283,7 @@ class Employee < ActiveRecord::Base
   belongs_to :company
 
   amoeba do
-    include_association :addresses
-    include_association :photos
+    include_associations [:addresses, :photos]
   end
 
 end


### PR DESCRIPTION
For easy migration from previous version it would be great to have mass exclusion/inclusion methods:

``` ruby
# Before (previous version)
amoeba do
  include_association [:posts, :users]
end

# After
amoeba do
  include_associations [:posts, :users]
end

# Instead of
amoeba do
  include_association :posts
  include_association :users
end
```
