### PR TITLE
Fix inheritance with extension

### DIFF
--- a/lib/amoeba/class_methods.rb
+++ b/lib/amoeba/class_methods.rb
@@ -16,6 +16,11 @@ module Amoeba
       @config
     end
 
+    def reset_amoeba(&block)
+      @config_block = block if block_given?
+      @config = Amoeba::Config.new(self)
+    end
+
     def amoeba_block
       @config_block
     end

--- a/lib/amoeba/cloner.rb
+++ b/lib/amoeba/cloner.rb
@@ -9,7 +9,7 @@ module Amoeba
     def_delegators :old_object, :_parent_amoeba, :_amoeba_settings,
                    :_parent_amoeba_settings
 
-    def_delegators :object_klass, :amoeba, :fresh_amoeba
+    def_delegators :object_klass, :amoeba, :fresh_amoeba, :reset_amoeba
 
     def initialize(object, options = {})
       @old_object = object
@@ -41,12 +41,13 @@ module Amoeba
     end
 
     def inherit_submissive_parent_settings
-      fresh_amoeba(&_parent_amoeba_settings)
+      reset_amoeba(&_amoeba_settings)
+      amoeba(&_parent_amoeba_settings)
       amoeba(&_amoeba_settings)
     end
 
     def inherit_parent_settings
-      return if amoeba.enabled || !_parent_amoeba.inherit
+      return if !_parent_amoeba.inherit
       return unless %w(strict relaxed submissive).include?(parenting_style.to_s)
       __send__("inherit_#{parenting_style}_parent_settings".to_sym)
     end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -379,3 +379,38 @@ end
 class BoxAnotherProduct < BoxProduct
   belongs_to :sub_product, class_name: 'BoxSubProduct'
 end
+
+# Inclusion inheritance
+class Stage < ActiveRecord::Base
+  has_many :listeners
+  has_many :specialists
+
+  amoeba do
+    include_association :listeners
+    include_association :specialists
+    nullify :external_id
+    propagate
+  end
+end
+
+class Participant < ActiveRecord::Base
+  belongs_to :stage
+end
+
+class Listener < Participant
+end
+
+class Specialist < Participant
+end
+
+class CustomStage < Stage
+  has_many :custom_rules, foreign_key: :stage_id
+
+  amoeba do
+    include_association :custom_rules
+  end
+end
+
+class CustomRule < ActiveRecord::Base
+  belongs_to :custom_stage
+end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -213,4 +213,23 @@ ActiveRecord::Schema.define do
     t.timestamps null: true
   end
 
+  create_table :stages, force: true do |t|
+    t.string   :title
+    t.string   :type
+    t.integer  :external_id
+    t.timestamps null: true
+  end
+
+  create_table :participants, force: true do |t|
+    t.string    :name
+    t.string    :type
+    t.integer   :stage_id
+    t.timestamps
+  end
+
+  create_table :custom_rules, force: true do |t|
+    t.string   :description
+    t.integer  :stage_id
+    t.timestamps
+  end
 end


### PR DESCRIPTION
Currently, inheritance not working as expected.
Consider the example:

``` ruby
class Stage < ActiveRecord::Base
  has_many :listeners
  has_many :specialists

  amoeba do
    include_association :listeners
    include_association :specialists
    nullify :external_id
    propagate
  end
end

class CustomStage < Stage
  has_many :custom_rules, foreign_key: :stage_id

  amoeba do
    include_association :custom_rules
  end
end
```

`CustomStage` will not contain `custom_rules`, because `@config_block` is replaced by parent class `config_block`. 
