### PR TITLE
Set next version to 3.2

### DIFF
--- a/lib/amoeba/version.rb
+++ b/lib/amoeba/version.rb
@@ -1,3 +1,3 @@
 module Amoeba
-  VERSION = '5.2.0'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
The version was set to 5.2, to track the Rails version, but this was never released on Rubygems. IMO, there is no reason to link to the Rail version unless it is the intention to support multiple major versions which is unnecessary for this gem. Therefore I am putting the version back to 3.2.

After this I intend to propose a version 4.0, which will drop support for unsupported Rails and Ruby versions.

If anyone reads this then please comment about whether this is sensible, or if the change could cause problems for anyone who is is pulling the gem straight from Github. I doubt it but I could be wrong.