### PR TITLE
Use lazy load hooks to extend ActiveRecord::Base

### DIFF
--- a/lib/amoeba.rb
+++ b/lib/amoeba.rb
@@ -16,5 +16,7 @@ require 'amoeba/instance_methods'
 module Amoeba
 end
 
-ActiveRecord::Base.extend Amoeba::ClassMethods
-ActiveRecord::Base.include Amoeba::InstanceMethods
+ActiveSupport.on_load :active_record do
+  extend Amoeba::ClassMethods
+  include Amoeba::InstanceMethods
+end


### PR DESCRIPTION
Extend ActiveRecord::Base functionality only after ActiveRecord has been fully loaded.

Ref: thoughtbot/factory_bot_rails#426

---

Hello, this is an attempt to fix a compatibility issue with the upcoming Factory Bot Rails 6.4.0.

This is the easiest thing that would work, but other approaches are possible, like an [autoload](https://api.rubyonrails.org/classes/ActiveSupport/Autoload.html) functionality