### PR TITLE
Pass coder to serialize as keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Drop support for Rails 5.2, Ruby 2.5 and 2.6. [https://github.com/amoeba-rb/amoeba/pull/120]
 * Notes on contributing. Github Actions for automate tests. [https://github.com/amoeba-rb/amoeba/pull/124]
+* Fix tests for Active Record after 7.1. [https://github.com/amoeba-rb/amoeba/pull/127]
 
 ### 3.3.0
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -110,7 +110,7 @@ class CustomThing < ActiveRecord::Base
     end
   end
 
-  serialize :value, ArrayPack
+  serialize :value, coder: ArrayPack
 
   before_create :hydrate_me
 


### PR DESCRIPTION
Passing coder to serialize as a positional argument is deprecated and will cause errors in Active Record after 7.1.

Fixes #125 