### PR TITLE
Allow `set` operation to take a lambda

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,5 @@ Style/Documentation:
   Enabled: false
 Metrics/MethodLength:
   Max: 15
+RSpec/NestedGroups:
+  Max: 4

--- a/docs/pre_processing_fields.md
+++ b/docs/pre_processing_fields.md
@@ -24,6 +24,15 @@ Set a field to a given value.
   end
 ```
 
+The field may be set to the return value of a lambda, so to set a field to the
+current time:
+
+```ruby
+  amoeba do
+    set datetime_field: ->() { Time.now }
+  end
+```
+
 ## regex
 
 To do

--- a/docs/pre_processing_fields.md
+++ b/docs/pre_processing_fields.md
@@ -1,0 +1,37 @@
+# Pre-Processing Fields
+
+## nullify
+
+To do
+
+## prepend
+
+To do
+
+## append
+
+To do
+
+## set
+
+Set a field to a given value.
+
+```ruby
+  amoeba do
+    set string_field: 'default string value'
+    set integer_field: 99
+    set boolean_field: false
+  end
+```
+
+## regex
+
+To do
+
+## override
+
+To do
+
+## customize
+
+To do

--- a/docs/pre_processing_fields.md
+++ b/docs/pre_processing_fields.md
@@ -33,6 +33,22 @@ current time:
   end
 ```
 
+Keyword parameters passed to the `amoeba_dup` command can also be used:
+
+```ruby
+  amoeba do
+    set string_field: ->(str_arg:) { str_arg }
+    set integer_field: ->(int_arg:) { int_arg }
+    set combined_field: ->(str_arg:, int_arg: 33, other_arg: 'default') { "#{str_arg} - #{int_arg} - #{other_arg}" }
+  end
+
+new_item = item.amoeba_dup(str_arg: 'new string', int_arg: 45)
+# => new_item.string_field = 'new_string'
+# => new_item.integer_field = 99
+# => new_item.combined_field = 'new_string - 99 - default'
+```
+
+
 ## regex
 
 To do

--- a/lib/amoeba/cloner.rb
+++ b/lib/amoeba/cloner.rb
@@ -13,9 +13,9 @@ module Amoeba
 
     def_delegators :object_klass, :amoeba, :fresh_amoeba, :reset_amoeba
 
-    def initialize(object, options = {})
+    def initialize(object, **kwargs)
       @old_object = object
-      @options    = options
+      @params = kwargs
       @object_klass = @old_object.class
       inherit_parent_settings
       @new_object = object.__send__(amoeba.dup_method)
@@ -135,7 +135,12 @@ module Amoeba
     def process_coercions
       # prepend any extra strings to indicate uniqueness of the new record(s)
       amoeba.coercions.each do |field, coercion|
-        @new_object[field] = coercion.is_a?(Proc) ? coercion.call : coercion.to_s
+        if coercion.is_a?(Proc)
+          keys = coercion.parameters.select { |pair| %i[key keyreq].include?(pair.first) }.map(&:second)
+          @new_object[field] = coercion.call(**@params.slice(*keys))
+        else
+          @new_object[field] = coercion.to_s
+        end
       end
     end
 

--- a/lib/amoeba/cloner.rb
+++ b/lib/amoeba/cloner.rb
@@ -135,7 +135,7 @@ module Amoeba
     def process_coercions
       # prepend any extra strings to indicate uniqueness of the new record(s)
       amoeba.coercions.each do |field, coercion|
-        @new_object[field] = coercion.to_s
+        @new_object[field] = coercion.is_a?(Proc) ? coercion.call : coercion.to_s
       end
     end
 

--- a/lib/amoeba/instance_methods.rb
+++ b/lib/amoeba/instance_methods.rb
@@ -33,8 +33,8 @@ module Amoeba
       end
     end
 
-    def amoeba_dup(options = {})
-      ::Amoeba::Cloner.new(self, options).run
+    def amoeba_dup(**kwargs)
+      ::Amoeba::Cloner.new(self, **kwargs).run
     end
   end
 end

--- a/lib/amoeba/macros/has_many.rb
+++ b/lib/amoeba/macros/has_many.rb
@@ -32,7 +32,7 @@ module Amoeba
         return if association.is_a?(ActiveRecord::Reflection::ThroughReflection)
 
         @old_object.__send__(relation_name).each do |old_obj|
-          copy_of_obj = old_obj.amoeba_dup(@options)
+          copy_of_obj = old_obj.amoeba_dup
           copy_of_obj[:"#{association.foreign_key}"] = nil
           relation_name = remapped_relation_name(relation_name)
           # associate this new child to the new parent object

--- a/lib/amoeba/macros/has_one.rb
+++ b/lib/amoeba/macros/has_one.rb
@@ -9,7 +9,7 @@ module Amoeba
         old_obj = @old_object.__send__(relation_name)
         return unless old_obj
 
-        copy_of_obj = old_obj.amoeba_dup(@options)
+        copy_of_obj = old_obj.amoeba_dup
         copy_of_obj[:"#{association.foreign_key}"] = nil
         relation_name = remapped_relation_name(relation_name)
         @new_object.__send__(:"#{relation_name}=", copy_of_obj)

--- a/spec/lib/amoeba/class_methods_spec.rb
+++ b/spec/lib/amoeba/class_methods_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe Amoeba::ClassMethods do
 
         it { expect(dup.test_field).to be(false) }
       end
+
+      context 'with a datetime field set by a lambda' do
+        let(:params) { { test_field: DateTime.parse('30 Jun 2024 18:19') } }
+        let(:field_type) { :datetime }
+        let(:config) do
+          <<~CONFIG
+            amoeba do
+              set test_field: ->() { Time.now }
+            end
+          CONFIG
+        end
+
+        before { travel_to DateTime.parse('1 Jul 2024 09:35') }
+        after { travel_back }
+
+        it { expect(dup.test_field).to eq(DateTime.parse('1 Jul 2024 09:35')) }
+      end
     end
   end
 end

--- a/spec/lib/amoeba/class_methods_spec.rb
+++ b/spec/lib/amoeba/class_methods_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Amoeba::ClassMethods do
+  describe '#amoeba' do
+    let(:dup) { test.amoeba_dup }
+    let(:test) { TestModel.new(**params) }
+
+    before do
+      stub_const 'TestModel', Class.new(ActiveRecord::Base)
+
+      ActiveRecord::Base.connection.drop_table :test_models, if_exists: true
+      ActiveRecord::Base.connection.schema_cache.clear!
+
+      ActiveRecord::Base.connection.create_table :test_models do |t|
+        t.column :test_field, field_type
+      end
+
+      TestModel.class_eval config
+    end
+
+    describe 'set' do
+      context 'with a static string value' do
+        let(:params) { { test_field: 'original string' } }
+        let(:field_type) { :string }
+        let(:config) do
+          <<~CONFIG
+            amoeba do
+              set test_field: 'default string value'
+            end
+          CONFIG
+        end
+
+        it { expect(dup.test_field).to eq('default string value') }
+      end
+
+      context 'with a static integer value' do
+        let(:params) { { test_field: 33 } }
+        let(:field_type) { :integer }
+        let(:config) do
+          <<~CONFIG
+            amoeba do
+              set test_field: 99
+            end
+          CONFIG
+        end
+
+        it { expect(dup.test_field).to eq(99) }
+      end
+
+      context 'with a static boolean value' do
+        let(:params) { { test_field: true } }
+        let(:field_type) { :boolean }
+        let(:config) do
+          <<~CONFIG
+            amoeba do
+              set test_field: false
+            end
+          CONFIG
+        end
+
+        it { expect(dup.test_field).to be(false) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ SimpleCov.start do
 end
 
 require 'active_record'
+require 'active_support/testing/time_helpers'
 require 'amoeba'
 
 adapter = if defined?(JRuby)
@@ -32,6 +33,7 @@ adapter = if defined?(JRuby)
 ActiveRecord::Base.establish_connection(adapter: adapter, database: ':memory:')
 
 ::RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
   config.order = :defined
 end
 


### PR DESCRIPTION
The `set` pre-processing operation will currently set a field to a static value. Issue #112 suggests allowing the field to be set according to a parameter passed to `ameoba_dup`.

`set` can now be defined to use the return value of a lambda and keyword arguments can be used on `amoeba_dup` to specify arguments to the lambdas:

```ruby
class Test < ActiveRecord::Base
  amoeba do
    set test_field: ->(arg:) { arg }
  end
end

t1 = Test.new
t2 = t1.amoeba_dup(arg: 123)
t2.test_field
# => 123
```

Note that the `@options` instance variable on the macro classes has been removed. It is not at all clear what was the purpose of this instance variable as it did not appear to be set anywhere and its removal has not affected any of the unit tests.